### PR TITLE
Remove shadowed loop variables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/abcxyz/abc/t/rest_server
 
-go 1.21
+go 1.22
 
 require (
 	github.com/abcxyz/pkg v0.7.1

--- a/main_test.go
+++ b/main_test.go
@@ -90,8 +90,6 @@ func TestHandleHello(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This is no longer required as of Go 1.22+
